### PR TITLE
[Fix] 최초 로그인 시 데이터 불러오는 시점 수정

### DIFF
--- a/PARD/Sources/Home/ViewControllers/HomeTabBarViewController.swift
+++ b/PARD/Sources/Home/ViewControllers/HomeTabBarViewController.swift
@@ -23,7 +23,6 @@ class HomeTabBarViewController: UITabBarController {
         setUpTabBarColor()
         setUpTabBarLayout()
         setUpTabBarItems()
-        getUsersMe()
         delegate = self
     }
     

--- a/PARD/Sources/User/ViewControllers/UserInfoPolicyViewController.swift
+++ b/PARD/Sources/User/ViewControllers/UserInfoPolicyViewController.swift
@@ -195,6 +195,7 @@ extension UserInfoPolicyViewController {
         self.navigationController?.isNavigationBarHidden = false
         view.backgroundColor = UIColor.pard.blackBackground
         setUpUI()
+        getUsersMe()
     }
     
     private func setUpUI() {


### PR DESCRIPTION
# ✅ 관련 issue
close #58 

<br>

# 🗣 설명
최초 로그인 시 사용자 정보를 불러오지 못했던 버그를 수정했습니다. 데이터를 서버로부터 불러오는 시점이 홈에 들어오는 시점보다 늦어져 있어 홈 진입 후 데이터가 불러와 화면에 보여지지 않았음
<img width="397" alt="스크린샷 2024-07-05 오후 2 42 07" src="https://github.com/Club-PARD/PARD_iOS/assets/97924765/91b84d5c-e62a-4bcb-a4c3-86a4b5439309">

<br>

## **📋 체크리스트**
구현한 부분 체크리스트
  - [X] 홈에 진입하기 전에 사용자 정보를 불러와 UserDefault에 저장하기

<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용
