### PR TITLE
[Fix] 내 점수 페이지 탭바 삭제

### DIFF
--- a/PARD.xcodeproj/xcuserdata/jinsejin.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/PARD.xcodeproj/xcuserdata/jinsejin.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>PARD.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>17</integer>
+			<integer>11</integer>
 		</dict>
 		<key>SnapKitPlayground (Playground) 1.xcscheme</key>
 		<dict>

--- a/PARD.xcworkspace/xcuserdata/jinsejin.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/PARD.xcworkspace/xcuserdata/jinsejin.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -9,7 +9,7 @@
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>9</integer>
 		</dict>
 		<key>SnapKitPlayground (Playground) 10.xcscheme</key>
 		<dict>
@@ -30,7 +30,7 @@
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>10</integer>
 		</dict>
 		<key>SnapKitPlayground (Playground) 3.xcscheme</key>
 		<dict>
@@ -80,7 +80,7 @@
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>8</integer>
 		</dict>
 	</dict>
 </dict>

--- a/PARD/Sources/Home/ViewControllers/HomeViewController.swift
+++ b/PARD/Sources/Home/ViewControllers/HomeViewController.swift
@@ -32,7 +32,7 @@ class HomeViewController: UIViewController {
     
     private let scrollView = UIScrollView()
     private let contentView = UIView()
-    
+  
     private func setNavigation() {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()

--- a/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
+++ b/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
@@ -16,6 +16,22 @@ class MyScoreViewController: UIViewController {
     private var rank2: Rank?
     private var rank3: Rank?
     
+    private let appearance = UINavigationBarAppearance().then {
+        $0.configureWithOpaqueBackground()
+        $0.backgroundColor = .pard.blackBackground
+        $0.shadowColor = .pard.blackBackground
+        $0.titleTextAttributes = [
+            .foregroundColor: UIColor.pard.white100,
+            .font: UIFont.pardFont.head1
+        ]
+    }
+    
+    private let previousAppearance = UINavigationBarAppearance().then {
+        $0.configureWithOpaqueBackground()
+        $0.backgroundColor = .pard.blackCard
+        $0.shadowColor = .pard.blackCard
+    }
+  
     private var toolTipView: ToolTipView?
     
     var scoreRecords: [(tag: String, title: String, date: String, points: String, pointsColor: UIColor)] = [
@@ -69,7 +85,26 @@ class MyScoreViewController: UIViewController {
         setupScoreStatusView()
         setupScoreRecordsView()
     }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.navigationBar.standardAppearance = previousAppearance
+        navigationController?.navigationBar.scrollEdgeAppearance  = previousAppearance
+        if let tabBarViewController = tabBarController as? HomeTabBarViewController {
+            tabBarViewController.floatingButton.isHidden = false
+        }
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if let tabBarViewController = tabBarController as? HomeTabBarViewController {
+            tabBarViewController.floatingButton.isHidden = true
+        }
+    }
+    
     private func setNavigation() {
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
         self.navigationItem.title = "내 점수"
         if let navigationBar = self.navigationController?.navigationBar {
             let appearance = UINavigationBarAppearance()
@@ -95,7 +130,7 @@ class MyScoreViewController: UIViewController {
     
     @objc func backButtonTapped() {
         let homeViewController = HomeViewController()
-        navigationController?.setViewControllers([homeViewController], animated: true)
+        navigationController?.popViewController(animated: false)
     }
     
     
@@ -254,7 +289,6 @@ class MyScoreViewController: UIViewController {
             $0.leading.equalToSuperview().offset(62)
             $0.top.equalToSuperview().offset(179)
         }
-        
         
         goldNameLabel.snp.makeConstraints {
             $0.leading.equalTo(goldRingImageView.snp.trailing).offset(8)
@@ -723,8 +757,6 @@ class MyScoreViewController: UIViewController {
             }
         }
     }
-    
-    
     
     class ToolTipView: UIView {
         

--- a/Pods/Pods.xcodeproj/xcuserdata/jinsejin.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Pods/Pods.xcodeproj/xcuserdata/jinsejin.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,22 +7,22 @@
 		<key>AppAuth.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>3</integer>
+			<integer>1</integer>
 		</dict>
 		<key>GTMAppAuth.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>10</integer>
+			<integer>5</integer>
 		</dict>
 		<key>GTMSessionFetcher.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>9</integer>
+			<integer>0</integer>
 		</dict>
 		<key>GoogleSignIn-GoogleSignIn.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>5</integer>
+			<integer>3</integer>
 		</dict>
 		<key>GoogleSignIn.xcscheme_^#shared#^_</key>
 		<dict>
@@ -32,7 +32,7 @@
 		<key>Pods-PARD.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>8</integer>
+			<integer>2</integer>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
# ✅ 관련 issue
close #87

<br>   

# 🗣 설명
- 내 점수 페이지 탭바 삭제
- UInNavigator를 popViewController로 고쳐 탭바 비활성화와 활성화 로직 정상화
<img width="290" alt="image" src="https://github.com/Club-PARD/PARD_iOS/assets/122281984/6071c1a6-2dcc-402f-886a-fc9b83fb4ef0">
<img width="281" alt="image" src="https://github.com/Club-PARD/PARD_iOS/assets/122281984/9e9f0a5a-ed10-4375-8432-2d250d5a29c1">

<br>

## **📋 체크리스트**
구현한 부분 체크리스트
  - [X] UInNavigator를 popViewController로 고쳐 탭바 비활성화와 활성화 로직 정상화
  - [X] 내 점수 페이지 탭바 삭제

<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용
