### PR TITLE
[Fix] 내점수화면 벌점 라벨 레이아웃 조정

### DIFF
--- a/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
+++ b/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
@@ -343,7 +343,7 @@ class MyScoreViewController: UIViewController {
             $0.top.equalToSuperview().offset(245)
             $0.leading.equalToSuperview().offset(24)
             $0.trailing.equalTo(view.snp.centerX).offset(-12)
-            $0.width.equalTo(155.5)
+//            $0.width.equalTo(155.5)
             $0.height.equalTo(68)
         }
         
@@ -359,7 +359,7 @@ class MyScoreViewController: UIViewController {
             $0.top.equalToSuperview().offset(245)
             $0.leading.equalTo(view.snp.centerX).offset(12)
             $0.trailing.equalToSuperview().offset(-24)
-            $0.width.equalTo(155.5)
+//            $0.width.equalTo(155.5)
             $0.height.equalTo(68)
         }
         
@@ -513,9 +513,9 @@ class MyScoreViewController: UIViewController {
         scoreStatusView.addSubview(penaltyPointsValueLabel)
         
         penaltyPointsValueLabel.snp.makeConstraints {
-            $0.top.equalTo(scoreStatusView.snp.top).offset(48)
-            $0.leading.equalTo(scoreStatusView.snp.leading).offset(230.5)
-            $0.trailing.equalTo(scoreStatusView.snp.trailing).offset(-67.5)
+            $0.top.equalTo(penaltyPointsLabel.snp.bottom).offset(8)
+            $0.width.equalTo(50)
+            $0.centerX.equalTo(penaltyPointsLabel)
         }
         
         let questionImageButton = UIButton().then {


### PR DESCRIPTION
# ✅ 관련 issue
close #136 

<br>
내점수화면 벌점 라벨 레이아웃 조정

# 🗣 설명

<img width="280" alt="image" src="https://github.com/user-attachments/assets/841ddaa1-da9f-42ab-83cc-9995396360a6">


<img width="280" alt="image" src="https://github.com/user-attachments/assets/3a2eb7a3-5ee5-46de-a2a7-c89ac2a3b344">

<br>

## **📋 체크리스트**
구현한 부분 체크리스트
  - [X] 내점수화면 벌점 라벨 레이아웃 조정
<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용
