### PR TITLE
[Fix] 내점수화면 top3 왕관 위치 수정 + 전체랭킹 확인하기 버튼 우측 패딩 수정 + 가장 최근 이벤트 빨간 점 추가 + 인스타그램, 웹사이트 링크 연결 + 전체 랭킹 페이지 랭킹 점수 '점'추가

### DIFF
--- a/PARD/Sources/HamBurgerTableViewCell.swift
+++ b/PARD/Sources/HamBurgerTableViewCell.swift
@@ -9,6 +9,8 @@ import UIKit
 
 protocol MenuTableViewCellButtonTapedDelegate : AnyObject {
     func cellButtonTaped(index : Int, isHiddenView : Bool)
+    func cellTapped(with url: URL)
+
 }
 
 class HamBurgerTableViewCell: UITableViewCell {
@@ -37,10 +39,31 @@ class HamBurgerTableViewCell: UITableViewCell {
         button.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
     }
     
+    
+    private var tapRecognizer: UITapGestureRecognizer!
+    
+    
+    @objc private func handleCellTap() {
+        let urlString: String
+        if subtitleLabel.text == "인스타 그램" {
+            urlString = "https://www.instagram.com/official_pard_/"
+        } else if subtitleLabel.text == "웹 사이트" {
+            urlString = "https://we-pard.com/"
+        } else {
+            return
+        }
+        
+        if let url = URL(string: urlString) {
+            delegate?.cellTapped(with: url)
+        }
+    }
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: "menuTableView")
         self.backgroundColor = .pard.blackCard
         setUpComponent()
+        tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleCellTap))
+        self.addGestureRecognizer(tapRecognizer)
     }
     
     required init?(coder: NSCoder) {

--- a/PARD/Sources/HamburgerBarView.swift
+++ b/PARD/Sources/HamburgerBarView.swift
@@ -126,6 +126,10 @@ extension HamburgerBarView : MenuTableViewCellButtonTapedDelegate {
         selectedNotionView = isHiddenView
         menuTableView.endUpdates()
     }
+    
+    func cellTapped(with url: URL) {
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
 }
 
 

--- a/PARD/Sources/MyScore/RankingTableViewCell.swift
+++ b/PARD/Sources/MyScore/RankingTableViewCell.swift
@@ -105,7 +105,7 @@ class RankingTableViewCell: UITableViewCell {
         
         userInfoLabel.text = userInfo.name
         userInfoPartLabel.text = userInfo.part
-        userInfoScoreLabel.text = "\(userInfo.totalBonus)"
+        userInfoScoreLabel.text = "\(userInfo.totalBonus)점"
         
         if rank == 1 {
             rankImageView.image = UIImage(named: "gold")

--- a/PARD/Sources/MyScore/ScoreRecordCell.swift
+++ b/PARD/Sources/MyScore/ScoreRecordCell.swift
@@ -16,6 +16,8 @@ class ScoreRecordCell: UICollectionViewCell {
     let pointsLabel = UILabel()
     let backgroundCardView = UIView()
     let separatorView = UIView()
+    let redDotView = UIView()
+    
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -33,6 +35,12 @@ class ScoreRecordCell: UICollectionViewCell {
         backgroundCardView.layer.borderWidth = 1
         backgroundCardView.layer.borderColor = UIColor.pard.blackBackground.cgColor
         contentView.addSubview(backgroundCardView)
+        
+        redDotView.backgroundColor = .pard.errorRed
+        redDotView.layer.cornerRadius = 3
+        redDotView.isHidden = true 
+        contentView.addSubview(redDotView)
+        
         
         tagLabel.font = UIFont.pardFont.body2
         tagLabel.textAlignment = .center
@@ -71,6 +79,11 @@ class ScoreRecordCell: UICollectionViewCell {
             make.width.equalTo(56)
             make.height.equalTo(24)
         }
+        redDotView.snp.makeConstraints { make in
+            make.top.equalTo(backgroundCardView).offset(13)
+            make.leading.equalTo(backgroundCardView).offset(29)
+            make.width.height.equalTo(5)
+        }
         
         titleLabel.snp.makeConstraints { make in
             make.top.equalTo(tagLabel.snp.bottom).offset(12)
@@ -98,13 +111,14 @@ class ScoreRecordCell: UICollectionViewCell {
         }
     }
     
-    func configure(with record: ReasonPardnerShip, isLastItem: Bool) {
+    func configure(with record: ReasonPardnerShip, isLastItem: Bool, isFirstItem: Bool) {
         tagLabel.text = record.reason
         titleLabel.text = record.detail
         dateLabel.text = formatDateString(record.createAt)
         pointsLabel.text = pointConfigure(point: record.point)
         separatorView.isHidden = isLastItem
-        
+        redDotView.isHidden = !isFirstItem
+
         if record.reason == "벌점" {
             tagLabel.layer.borderColor = UIColor.pard.errorRed.cgColor
             tagLabel.textColor = .pard.errorRed

--- a/PARD/Sources/MyScore/ScoreRecordsView.swift
+++ b/PARD/Sources/MyScore/ScoreRecordsView.swift
@@ -67,7 +67,8 @@ class ScoreRecordsView: UIView, UICollectionViewDataSource, UICollectionViewDele
         
         let record = scoreRecords[indexPath.item]
         let isLastItem = indexPath.item == scoreRecords.count - 1
-        cell.configure(with: record, isLastItem: isLastItem)
+        let isFirstItem = indexPath.item == 0
+        cell.configure(with: record, isLastItem: isLastItem, isFirstItem: isFirstItem)
         return cell
     }
 }

--- a/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
+++ b/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
@@ -65,8 +65,6 @@ class MyScoreViewController: UIViewController {
             print("Not enough data in rankList")
         }
         setupRankingMedals()
-        setupRankingButton()
-        setupCrownImages()
         setupScoreView()
         setupScoreStatusView()
         setupScoreRecordsView()
@@ -124,31 +122,6 @@ class MyScoreViewController: UIViewController {
             $0.height.equalTo(36)
         }
     }
-    
-    private func setupRankingButton() {
-        let rankingButton = UIButton(type: .system).then {
-            $0.setTitle("전체랭킹 확인하기", for: .normal)
-            $0.setTitleColor(.pard.gray30, for: .normal)
-            $0.layer.cornerRadius = 10
-            $0.addTarget(self, action: #selector(rankingButtonTapped), for: .touchUpInside)
-        }
-        view.addSubview(rankingButton)
-        
-        rankingButton.snp.makeConstraints {
-            $0.leading.equalToSuperview().offset(257)
-            $0.top.equalToSuperview().offset(327)
-            $0.width.equalTo(120)
-            $0.height.equalTo(14)
-        }
-        
-        let attributedString = NSMutableAttributedString(string: "전체랭킹 확인하기", attributes: [
-            .font: UIFont.pardFont.body1,
-            .foregroundColor: UIColor.pard.gray30
-        ])
-        attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: NSRange(location: 0, length: attributedString.length))
-        rankingButton.setAttributedTitle(attributedString, for: .normal)
-    }
-    
     
     private func setupRankingMedals() {
         guard let rank1 = rank1, let rank2 = rank2, let rank3 = rank3 else { return }
@@ -298,16 +271,13 @@ class MyScoreViewController: UIViewController {
             $0.top.equalToSuperview().offset(197)
             $0.trailing.equalToSuperview().offset(-36)
         }
-    }
-
-    
-    private func setupCrownImages() {
+        
         let goldCrownImageView = UIImageView(image: UIImage(named: "gold"))
         view.addSubview(goldCrownImageView)
         
         goldCrownImageView.snp.makeConstraints {
-            $0.centerX.equalToSuperview().offset(-155)
-            $0.top.equalTo(pardnerShipLabel.snp.bottom).offset(16)
+            $0.leading.equalToSuperview().offset(32)
+            $0.top.equalTo(goldRingImageView.snp.top).offset(-10)
             $0.width.height.equalTo(20)
         }
         
@@ -316,7 +286,7 @@ class MyScoreViewController: UIViewController {
         
         silverCrownImageView.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(156)
-            $0.top.equalTo(pardnerShipLabel.snp.bottom).offset(16)
+            $0.top.equalTo(silverRingImageView.snp.top).offset(-10)
             $0.width.height.equalTo(20)
         }
         
@@ -325,7 +295,7 @@ class MyScoreViewController: UIViewController {
         
         bronzeCrownImageView.snp.makeConstraints {
             $0.trailing.equalToSuperview().offset(-91)
-            $0.top.equalTo(pardnerShipLabel.snp.bottom).offset(16)
+            $0.top.equalTo(bronzeRingImageView.snp.top).offset(-10)
             $0.width.height.equalTo(20)
         }
     }
@@ -362,6 +332,28 @@ class MyScoreViewController: UIViewController {
 //            $0.width.equalTo(155.5)
             $0.height.equalTo(68)
         }
+        
+        let rankingButton = UIButton(type: .system).then {
+            $0.setTitle("전체랭킹 확인하기", for: .normal)
+            $0.setTitleColor(.pard.gray30, for: .normal)
+            $0.layer.cornerRadius = 10
+            $0.addTarget(self, action: #selector(rankingButtonTapped), for: .touchUpInside)
+        }
+        view.addSubview(rankingButton)
+        
+        rankingButton.snp.makeConstraints {
+            $0.centerX.equalTo(totalScoreBorderView.snp.centerX).offset(33)
+            $0.top.equalTo(totalScoreBorderView.snp.bottom).offset(14)
+            $0.width.equalTo(90)
+            $0.height.equalTo(18)
+        }
+        
+        let attributedString = NSMutableAttributedString(string: "전체랭킹 확인하기", attributes: [
+            .font: UIFont.pardFont.body1,
+            .foregroundColor: UIColor.pard.gray30
+        ])
+        attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: NSRange(location: 0, length: attributedString.length))
+        rankingButton.setAttributedTitle(attributedString, for: .normal)
         
         let myScoreLabel = UILabel().then {
             $0.text = "파트 내 랭킹"
@@ -443,6 +435,7 @@ class MyScoreViewController: UIViewController {
             $0.trailing.equalToSuperview().offset(-24)
             $0.height.equalTo(92)
         }
+        
         
         let partPointsLabel = UILabel().then {
             $0.text = "파트 포인트"

--- a/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
+++ b/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
@@ -135,14 +135,14 @@ class MyScoreViewController: UIViewController {
         view.addSubview(rankingButton)
         
         rankingButton.snp.makeConstraints {
-            $0.leading.equalToSuperview().offset(240)
-            $0.top.equalToSuperview().offset(325)
+            $0.leading.equalToSuperview().offset(257)
+            $0.top.equalToSuperview().offset(327)
             $0.width.equalTo(120)
             $0.height.equalTo(14)
         }
         
         let attributedString = NSMutableAttributedString(string: "전체랭킹 확인하기", attributes: [
-            .font: UIFont.pardFont.body3,
+            .font: UIFont.pardFont.body1,
             .foregroundColor: UIColor.pard.gray30
         ])
         attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: NSRange(location: 0, length: attributedString.length))


### PR DESCRIPTION
# ✅ 관련 issue
close #138 
close #139 
close #140 
close #141 
close #142 

<br>

# 🗣 설명

 - 내점수 페이지 '전체랭킹 확인하기' 우측 패딩 수정
 - 내점수화면 top 3위 왕관 위치 수정
 - UPCOMMING EVENT에서 가장 최근 이벤트에 빨간 점 추가하기
<img width="330" alt="image" src="https://github.com/user-attachments/assets/48202f15-6c6e-4a72-bd51-ddfaaf5b8d14">

 - 전체 랭킹 페이지 랭킹 점수 뒷부분 '점' 추가

<img width="330" alt="image" src="https://github.com/user-attachments/assets/739b2ce6-1f15-480f-b355-ad609f7a01a6">

 - 인스타그램, 웹사이트 링크 연결하기
<img width="330" alt="image" src="https://github.com/user-attachments/assets/8b83febf-32a1-483a-96f3-30ecc2a10f76">
<img width="280" alt="image" src="https://github.com/user-attachments/assets/c07b0c49-c969-4418-b82c-4ae08ee0ec0e">
<img width="280" alt="image" src="https://github.com/user-attachments/assets/bf8d466d-8467-4069-9eef-9d5a03673803">

<br>

## **📋 체크리스트**

구현한 부분 체크리스트
  - [X] 내점수 페이지 '전체랭킹 확인하기' 우측 패딩 수정
  - [X] 전체 랭킹 페이지 랭킹 점수 뒷부분 '점' 추가
  - [X] 내점수화면 top 3위 왕관 위치 수정
  - [X] 구글폼, 인스타그램, 웹사이트 링크 연결하기
  - [X] UPCOMMING EVENT에서 가장 최근 이벤트에 빨간 점 추가하기


<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용
