### PR TITLE
[Fix] 내점수화면 점수기록 텍스트 왼쪽 여백 수정

### DIFF
--- a/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
+++ b/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
@@ -578,7 +578,7 @@ class MyScoreViewController: UIViewController {
         
         scoreRecordsTitleLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(531)
-            $0.leading.equalToSuperview().offset(24)
+            $0.leading.equalToSuperview().offset(28)
             $0.trailing.equalToSuperview().offset(-280)
         }
         


### PR DESCRIPTION
# ✅ 관련 issue
close #149 

<br>

# 🗣 설명
 - 내점수화면 점수기록 텍스트 왼쪽 여백 수정

<br>


<img width="330" alt="image" src="https://github.com/user-attachments/assets/01fc6b75-dea0-4004-be3d-a2743c46bea3">


## **📋 체크리스트**
구현한 부분 체크리스트
  - [X] 내점수화면 점수기록 텍스트 왼쪽 여백 수정

<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용
