### PR TITLE
[Fix] 내점수화면 파드포인트 글씨 크기 수정

### DIFF
--- a/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
+++ b/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
@@ -436,20 +436,41 @@ class MyScoreViewController: UIViewController {
             $0.height.equalTo(92)
         }
         
+        let partPointsView = UIView().then {
+            $0.backgroundColor = .clear
+        }
+        scoreStatusView.addSubview(partPointsView)
+
+        let penaltyPointsView = UIView().then {
+            $0.backgroundColor = .clear
+        }
+        
+        scoreStatusView.addSubview(penaltyPointsView)
+
+        partPointsView.snp.makeConstraints {
+            $0.leading.top.bottom.equalToSuperview()
+            $0.width.equalTo(scoreStatusView).multipliedBy(0.5)
+        }
+
+        penaltyPointsView.snp.makeConstraints {
+            $0.trailing.top.bottom.equalToSuperview()
+            $0.width.equalTo(scoreStatusView).multipliedBy(0.5)
+        }
         
         let partPointsLabel = UILabel().then {
-            $0.text = "파트 포인트"
+            $0.text = "파드 포인트"
             $0.font = UIFont.pardFont.body2
             $0.textColor = .pard.gray10
             $0.textAlignment = .center
         }
-        scoreStatusView.addSubview(partPointsLabel)
+        partPointsView.addSubview(partPointsLabel)
+
         
         partPointsLabel.snp.makeConstraints {
-            $0.top.equalTo(scoreStatusView.snp.top).offset(24)
-            $0.leading.equalTo(scoreStatusView.snp.leading).offset(54.5)
-            $0.trailing.equalTo(scoreStatusView.snp.trailing).offset(-217.5)
+            $0.top.equalToSuperview().offset(24)
+            $0.centerX.equalToSuperview()
         }
+
         
         let partPointsValueLabel = UILabel().then {
             $0.text = "+\(UserDefaults.standard.string(forKey: "userTotalBonus") ?? "10")점"
@@ -459,14 +480,12 @@ class MyScoreViewController: UIViewController {
             $0.adjustsFontSizeToFitWidth = true
             $0.minimumScaleFactor = 0.5
         }
-        scoreStatusView.addSubview(partPointsValueLabel)
-        
+        partPointsView.addSubview(partPointsValueLabel)
+
         partPointsValueLabel.snp.makeConstraints {
-            $0.top.equalTo(scoreStatusView.snp.top).offset(48)
-            $0.leading.equalTo(scoreStatusView.snp.leading).offset(65)
-            $0.trailing.equalTo(scoreStatusView.snp.trailing).offset(-228)
+            $0.top.equalTo(partPointsLabel.snp.bottom).offset(8)
+            $0.centerX.equalToSuperview()
         }
-        
         let separatorView = UIView().then {
             $0.backgroundColor = .pard.gray30
         }
@@ -488,13 +507,7 @@ class MyScoreViewController: UIViewController {
             $0.adjustsFontSizeToFitWidth = true
             $0.minimumScaleFactor = 0.5
         }
-        scoreStatusView.addSubview(penaltyPointsLabel)
-        
-        penaltyPointsLabel.snp.makeConstraints {
-            $0.top.equalTo(scoreStatusView.snp.top).offset(24)
-            $0.leading.equalTo(scoreStatusView.snp.leading).offset(234.5)
-            $0.trailing.equalTo(scoreStatusView.snp.trailing).offset(-71.5)
-        }
+        penaltyPointsView.addSubview(penaltyPointsLabel)
         
         let penaltyPointsValueLabel = UILabel().then {
             $0.text = "-\(UserDefaults.standard.string(forKey: "userTotalMinus") ?? "10")점"
@@ -503,12 +516,16 @@ class MyScoreViewController: UIViewController {
             $0.textAlignment = .center
             
         }
-        scoreStatusView.addSubview(penaltyPointsValueLabel)
+        penaltyPointsView.addSubview(penaltyPointsValueLabel)
         
+        penaltyPointsLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(24)
+            $0.centerX.equalToSuperview()
+        }
+
         penaltyPointsValueLabel.snp.makeConstraints {
             $0.top.equalTo(penaltyPointsLabel.snp.bottom).offset(8)
-            $0.width.equalTo(50)
-            $0.centerX.equalTo(penaltyPointsLabel)
+            $0.centerX.equalToSuperview()
         }
         
         let questionImageButton = UIButton().then {


### PR DESCRIPTION
# ✅ 관련 issue
close #189 

<br>

# 🗣 설명
 - 파드포인트에서 두자리수가 되면 글씨가 작아지는 현상 수정

<img width="330" alt="스크린샷 2024-07-28 오후 2 34 50" src="https://github.com/user-attachments/assets/62fdb75e-ce20-4652-afeb-853daf20bbe7">

<img width="330" alt="스크린샷 2024-07-28 오후 2 34 50" src="https://github.com/user-attachments/assets/e0ac32ee-e55a-48d1-80d2-b04f8215f233">

<br>

## **📋 체크리스트**
구현한 부분 체크리스트
  - [X] 파드포인트에서 두자리수가 되면 글씨가 작아지는 현상 수정

<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용