### PR TITLE
[Fix] 파드 로고 Press 효과 제거 및 이스터에그 추가

### DIFF
--- a/PARD.xcodeproj/project.pbxproj
+++ b/PARD.xcodeproj/project.pbxproj
@@ -824,7 +824,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.one.ram2.PARD-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -858,7 +858,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.one.ram2.PARD-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/PARD/Sources/Home/ViewControllers/HomeViewController.swift
+++ b/PARD/Sources/Home/ViewControllers/HomeViewController.swift
@@ -10,6 +10,7 @@ import SnapKit
 import Then
 
 class HomeViewController: UIViewController {
+    private var esterEggCount = 0
     private lazy var topView = HomeTopView(viewController: self).then { view in
         view.backgroundColor = .pard.blackCard
         view.layer.cornerRadius = 40.0
@@ -42,14 +43,32 @@ class HomeViewController: UIViewController {
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
         navigationController?.navigationBar.standardAppearance = appearance
         
-        let homeButton = UIBarButtonItem(image: UIImage(named: "pardHomeLogo")?.withRenderingMode(.alwaysOriginal), style: .plain, target: self, action: .none)
+        let homeButton = UIButton(type: .custom)
+        homeButton.setImage(UIImage(named: "pardHomeLogo")?.withRenderingMode(.alwaysOriginal), for: .normal)
+        homeButton.showsTouchWhenHighlighted = false
+        homeButton.setImage(homeButton.image(for: .normal), for: .highlighted)
+        homeButton.addTarget(self, action: #selector(logoTapped), for: .touchUpInside)
+        
+        let homeBarButtonItem = UIBarButtonItem(customView: homeButton)
         let menuButton = UIBarButtonItem(image: UIImage(named: "menu")?.withRenderingMode(.alwaysOriginal), style: .plain, target: self, action: #selector(menuButtonTapped))
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
         flexibleSpace.width = 10
-        self.navigationItem.leftBarButtonItem = homeButton
+        self.navigationItem.leftBarButtonItem = homeBarButtonItem
         self.navigationItem.rightBarButtonItems = [flexibleSpace,menuButton]
     }
-   
+    
+    @objc private func logoTapped() {
+        print("tapped")
+        esterEggCount += 1
+        if (esterEggCount == 10) {
+            print("10 됐음 !! ")
+            if let url = URL(string: "https://we-pard.notion.site/d5e1d460c05844c4b810816ff502d5db?pvs=4") {
+                UIApplication.shared.open(url)
+            }
+        }
+        
+    }
+    
     @objc private func menuButtonTapped() {
         let menuBar = HamburgerBarViewController()
         menuBar.modalPresentationStyle = .overCurrentContext

--- a/Pods/Pods.xcodeproj/xcuserdata/ram.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Pods/Pods.xcodeproj/xcuserdata/ram.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,32 +7,32 @@
 		<key>AppAuth.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>4</integer>
 		</dict>
 		<key>GTMAppAuth.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>4</integer>
+			<integer>1</integer>
 		</dict>
 		<key>GTMSessionFetcher.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>6</integer>
+			<integer>2</integer>
 		</dict>
 		<key>GoogleSignIn-GoogleSignIn.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>3</integer>
+			<integer>5</integer>
 		</dict>
 		<key>GoogleSignIn.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>6</integer>
 		</dict>
 		<key>Pods-PARD.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>5</integer>
+			<integer>3</integer>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
# ✅ 관련 issue
close #229 

<br>

# 🗣 설명

<img width="293" alt="스크린샷 2024-08-10 오후 4 17 13" src="https://github.com/user-attachments/assets/c0333879-3fec-4bcd-bf38-67ebf0e918ea">

<img width="293" alt="스크린샷 2024-08-10 오후 4 17 02" src="https://github.com/user-attachments/assets/0faa7753-bf3c-4401-8d39-0b372ac8f8aa">



<br>

## **📋 체크리스트**
구현한 부분 체크리스트
  - [X] 파드 로고 Press 효과 제거 및 이스터에그 추가

<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용

파드 홈화면 로고 10번 터치시 이스터에그
