### PR TITLE
[fix] 랭킹 페이지에서 내 점수 페이지로 갈 때 탭바 안나오게 하기

### DIFF
--- a/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
+++ b/PARD/Sources/MyScore/ViewControllers/MyScoreViewController.swift
@@ -696,10 +696,12 @@ extension MyScoreViewController {
         setupScoreView()
         setupScoreStatusView()
         setupScoreRecordsView()
-        
-    
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        removeTabBarFAB(bool: true)
+    }
     
     private func removeTabBarFAB(bool : Bool) {
         tabBarController?.setTabBarVisible(visible: !bool, animated: false)

--- a/PARD/Sources/MyScore/ViewControllers/RankingViewController.swift
+++ b/PARD/Sources/MyScore/ViewControllers/RankingViewController.swift
@@ -90,6 +90,7 @@ class RankingViewController: UIViewController {
     }
 
     @objc func backButtonTapped() {
+        removeTabBarFAB(bool: true)
         navigationController?.popViewController(animated: true)
     }
     


### PR DESCRIPTION
# ✅ 관련 issue
close #240 

<br>

# 🗣 설명
- 랭킹 페이지에서 내 점수 페이지로 갈 때 탭바 안나오게 하기

https://github.com/user-attachments/assets/4a220947-4efd-4b50-94e9-ade7e7802754


## **📋 체크리스트**
구현한 부분 체크리스트
  - [X]  랭킹 페이지에서 내 점수 페이지로 갈 때 탭바 안나오게 하기

<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용
