### PR TITLE
[fix] upcommingVIew 데이터가 없을 때 eventTypeLabel의 백그라운드 컬러 수정

### DIFF
--- a/PARD/Sources/Home/HomeUpcommingView.swift
+++ b/PARD/Sources/Home/HomeUpcommingView.swift
@@ -107,7 +107,7 @@ class HomeUpcommingView : UIView {
         stackView.addArrangedSubview(eventDateLabel)
         stackView.addArrangedSubview(eventLocationLabel)
         
-        eventTypeLabel.backgroundColor = .gradientColor.gra
+        
         upcommingLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(20)
             make.leading.equalToSuperview().offset(24)
@@ -206,6 +206,7 @@ extension HomeUpcommingView {
         contentLabel.text = eventContentLabelSetup(upcomingEvents[0].content, upcomingEvents[0].part)
         eventDateLabel.text = formattedDateString(from: upcomingDate)
         eventTypeLabel.text = upcomingEvents[0].part
+        eventTypeLabel.backgroundColor = .gradientColor.gra
         
     }
     


### PR DESCRIPTION
# ✅ 관련 issue
close #
view가 로드 될 때 backgroundColor가 설정되도록 하지 않게 하였습니다.

<br>

# 🗣 설명
<img width="302" alt="image" src="https://github.com/user-attachments/assets/c9058b56-db40-445e-a817-0371411afbe6">

<img width="330" alt="image" src="https://github.com/user-attachments/assets/c5253c2f-2de6-499f-9a02-fc6ea92bfece">

view가 로드 될 때 backgroundColor가 설정되도록 하지 않게 하였습니다.

<br>

## **📋 체크리스트**
구현한 부분 체크리스트
  - [X] upcommingView 데이터가 없을 때 [eventTypeLabel의 백그라운드 컬러 수정]

<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용
