### PR TITLE
[Fix] 전체랭킹_UI_테이블뷰 구분선 길이 조절

### DIFF
--- a/PARD/Sources/MyScore/ViewControllers/RankingViewController.swift
+++ b/PARD/Sources/MyScore/ViewControllers/RankingViewController.swift
@@ -164,8 +164,8 @@ extension RankingViewController: UITableViewDelegate, UITableViewDataSource {
             separatorView.backgroundColor = UIColor.pard.gray30
             cell.contentView.addSubview(separatorView)
             separatorView.snp.makeConstraints { make in
-                make.leading.equalTo(cell.contentView.snp.leading).offset(0)
-                make.trailing.equalTo(cell.contentView.snp.trailing).offset(0)
+                make.leading.equalTo(cell.contentView.snp.leading).offset(8)
+                make.trailing.equalTo(cell.contentView.snp.trailing).offset(-8)
                 make.bottom.equalTo(cell.contentView.snp.bottom)
                 make.height.equalTo(1)
             }


### PR DESCRIPTION
# ✅ 관련 issue
close #276 

<br>

# 🗣 설명
회색 박스에 닿는데 그 아래부터는 안닿음 → 모두 닿지 않게 바꿔주세요!

테이블뷰에 구분선이 닿지 않도록 수정하기

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b520c89c-a051-4f0d-aba5-9da988286df9">

<br>

## **📋 체크리스트**
구현한 부분 체크리스트
  - [X] 테이블뷰 구분선 길이 조절

<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용
