### PR TITLE
[Chore] iOS 최소 버전 낮추기

### DIFF
--- a/PARD.xcodeproj/project.pbxproj
+++ b/PARD.xcodeproj/project.pbxproj
@@ -844,8 +844,8 @@
 				CODE_SIGN_ENTITLEMENTS = PARD/PARD.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = S65HTAH6VL;
+				CURRENT_PROJECT_VERSION = 3;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PARD/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "\"camera access\"";
@@ -854,7 +854,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -877,8 +877,8 @@
 				CODE_SIGN_ENTITLEMENTS = PARD/PARD.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = S65HTAH6VL;
+				CURRENT_PROJECT_VERSION = 3;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PARD/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "\"camera access\"";
@@ -887,7 +887,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
# ✅ 관련 issue
close #297 

<br>

# 🗣 설명

iOS 버전이 낮아서 출석앱을 사용하지 못하는 파디가 있어 앱 사용가능 iOS 버전을 낮춥니다.

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/67f1ee22-2bda-4343-b300-9040a26b8a1e" width="700"></td>
  </tr>
  <tr>
    <td align="center">[ iOS 최소버전 및 빌드 ]</td>
  </tr>
</table>


<br>

## **📋 체크리스트**
구현한 부분 체크리스트

  - [x] 앱 사용 가능 iOS 최소버전을 현재 17.0 -> 16.0으로 낮춥니다.
  - [x] 앱 버전을 높이기에는 너무 사소한 업데이트라 앱 Build를 높입니다.

<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용
