### PR TITLE
[Fix] 홈뷰의 하위뷰에서도 로고가 생성되는 문제 해결

### DIFF
--- a/PARD/Sources/Home/ViewControllers/HomeViewController.swift
+++ b/PARD/Sources/Home/ViewControllers/HomeViewController.swift
@@ -11,6 +11,7 @@ import Then
 
 class HomeViewController: UIViewController {
     private var esterEggCount = 0
+    private let logoImageViewTag = 999          // 로고 식별을 위한 태그
     
     private lazy var topView = HomeTopView(viewController: self).then { view in
         view.backgroundColor = .pard.blackCard
@@ -33,7 +34,7 @@ class HomeViewController: UIViewController {
     
     private let scrollView = UIScrollView()
     private let contentView = UIView()
-  
+    
     private func setNavigation() {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
@@ -42,21 +43,6 @@ class HomeViewController: UIViewController {
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
         navigationController?.navigationBar.standardAppearance = appearance
         
-        let logoImageView = UIImageView(image: UIImage(named: "pardHomeLogo"))
-        logoImageView.contentMode = .scaleAspectFit
-        logoImageView.translatesAutoresizingMaskIntoConstraints = false
-        logoImageView.isUserInteractionEnabled = true
-        
-        let logoTapGesture = UITapGestureRecognizer(target: self, action: #selector(logoTapped))
-        logoImageView.addGestureRecognizer(logoTapGesture)
-        
-        navigationController?.navigationBar.addSubview(logoImageView)
-        
-        NSLayoutConstraint.activate([
-            logoImageView.leadingAnchor.constraint(equalTo: navigationController!.navigationBar.leadingAnchor, constant: 20),
-            logoImageView.centerYAnchor.constraint(equalTo: navigationController!.navigationBar.centerYAnchor)
-        ])
-
         let menuButton = UIBarButtonItem(
             image: UIImage(named: "menu")?.withRenderingMode(.alwaysOriginal),
             style: .plain,
@@ -68,6 +54,37 @@ class HomeViewController: UIViewController {
         flexibleSpace.width = 10
         self.navigationItem.rightBarButtonItems = [flexibleSpace, menuButton]
     }
+    
+    // 네비게이션바 로고 추가
+    private func addLogoToNavigationBar() {
+        guard let navBar = navigationController?.navigationBar else { return }
+        
+        // 중복 추가 방지
+        if navBar.viewWithTag(logoImageViewTag) != nil { return }
+        
+        let logoImageView = UIImageView(image: UIImage(named: "pardHomeLogo"))
+        logoImageView.contentMode = .scaleAspectFit
+        logoImageView.translatesAutoresizingMaskIntoConstraints = false
+        logoImageView.isUserInteractionEnabled = true
+        logoImageView.tag = logoImageViewTag
+        
+        // 탭 제스처
+        let logoTapGesture = UITapGestureRecognizer(target: self, action: #selector(logoTapped))
+        logoImageView.addGestureRecognizer(logoTapGesture)
+        
+        navBar.addSubview(logoImageView)
+        
+        NSLayoutConstraint.activate([
+            logoImageView.leadingAnchor.constraint(equalTo: navBar.leadingAnchor, constant: 20),
+            logoImageView.centerYAnchor.constraint(equalTo: navBar.centerYAnchor)
+        ])
+    }
+    
+    // 네비게이션바 로고 제거
+    private func removeLogoFromNavigationBar() {
+        navigationController?.navigationBar.viewWithTag(logoImageViewTag)?.removeFromSuperview()
+    }
+    
     
     @objc private func logoTapped() {
         print("tapped")
@@ -109,6 +126,12 @@ extension HomeViewController {
         super.viewWillAppear(animated)
         self.tabBarController?.tabBar.isHidden = false
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
+        addLogoToNavigationBar()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        removeLogoFromNavigationBar()
     }
     
     private func setUpUI() {


### PR DESCRIPTION
# ✅ 관련 issue
close #303

<br>

# 🗣 설명

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/067b7330-362b-461d-ad08-8331837409e3" width="200"></td>
    <td><img src="https://github.com/user-attachments/assets/945a3eeb-fcfd-4b1a-a45d-6e8eb59f457b" width="200"></td>
    <td><img src="https://github.com/user-attachments/assets/ce5f5d85-fde1-44e5-910f-1e0f07e4ec02" width="200"></td>
    <td><img src="https://github.com/user-attachments/assets/ae63eaaa-86eb-4685-be3c-c0c95e7cc01b" width="200"></td>
  </tr>
  <tr>
    <td align="center">[ 파드너십 하위뷰 (전) ]</td>
    <td align="center">[ 일정 하위뷰 (전) ]</td>
    <td align="center">[ 파드너십 하위뷰 (후) ]</td>
    <td align="center">[ 일정 하위뷰 (후) ]</td>
  </tr>
</table>


<br>

## **📋 체크리스트**
구현한 부분 체크리스트
  - [X] 홈뷰의 하위뷰인 '파드너십 더보기'에서도 로고가 나타나서 뒤로가기 버튼을 방해하는 문제를 해결했습니다.
  - [X] 홈뷰의 하위뷰인 '다가오는 일정 더보기'에서도 로고가 나타나서 뒤로가기 버튼을 방해하는 문제를 해결했습니다.

<br>

## 기타
기타 하고 싶은 이야기 혹은, 공유할 내용
